### PR TITLE
Update email.php

### DIFF
--- a/triggers/email.php
+++ b/triggers/email.php
@@ -487,9 +487,6 @@ class Email
                     wp_mail(get_bloginfo('admin_email'), $mail_subject, $mail_body, $headers, $this->attachments);
                 }
 
-                if ($record_entries) {
-                    Entries::post($newEntry);
-                }
 
                 $this->ExternalServiceHandler->handle($newEntry);
                 $this->attempt_success($template);
@@ -501,10 +498,11 @@ class Email
             $this->attempt_success($template);
 
 
-            if ($record_entries) {
+        }
+		
+		if ($record_entries) {
 
-                Entries::post($newEntry);
-            }
+	        Entries::post($newEntry);
         }
     }
 }


### PR DESCRIPTION
Move 

`
            if ($record_entries) {

                Entries::post($newEntry);
            }
`
outside of the $send_email === true if statement. As it stands, you cannot send the output of the form to an email address other than admin _and_ save the entry to the database. Moving this $record_entries if statement outside allows it to be saved as long as the Record Entries tag is added to the action of the form in the settings of the block.