### PR TITLE
Fix email trigger (for issue #187)

### DIFF
--- a/triggers/email.php
+++ b/triggers/email.php
@@ -478,6 +478,10 @@ class Email
                     wp_mail($template['email'], $mail_subject, $mail_body, $headers, $this->attachments);
                 }
 
+                if ($record_entries) {
+                    Entries::post($newEntry);
+                }
+
                 $this->ExternalServiceHandler->handle($newEntry);
                 $this->attempt_success($template);
             } else {


### PR DESCRIPTION
Fixes #187 whereby entries aren't saved for forms if a "To" email address is listed in the "Email Notification" setting of the parent Gutenberg Form block. Tested as a plugin edit at [mcgillmed.com](https://mcgillmed.com)