### PR TITLE
Wrong include path for wp-load.php

### DIFF
--- a/dashboard/dashboard.php
+++ b/dashboard/dashboard.php
@@ -4,8 +4,7 @@
 require_once plugin_dir_path(__DIR__) . 'triggers/functions.php';
 require_once plugin_dir_path(__DIR__) . 'export/index.php';
 
-$path = preg_replace('/wp-content(?!.*wp-content).*/', '', __DIR__);
-include($path . 'wp-load.php');
+include(ABSPATH . 'wp-load.php');
 require_once(ABSPATH . 'wp-admin/includes/plugin-install.php');
 require_once(ABSPATH . 'wp-admin/includes/file.php');
 require_once(ABSPATH . 'wp-admin/includes/misc.php');


### PR DESCRIPTION
Fixed include path for wp-load.php The wp-content directory can be various on WordPress installations and should not be hardcoded for determine a path. See https://codex.wordpress.org/Determining_Plugin_and_Content_Directories for more information.